### PR TITLE
add checking for fursona.json

### DIFF
--- a/api/[domain]/fursona.ts
+++ b/api/[domain]/fursona.ts
@@ -4,10 +4,13 @@ export const config = {
 
 async function fetcher(url: string) {
 	console.log(`https://${url}/.well-known/fursona`);
-	const res = await fetch(`https://${url}/.well-known/fursona`);
+	let res = await fetch(`https://${url}/.well-known/fursona`);
 	// If 404, return null
 	if (res.status === 404) {
-		return null;
+		res = await fetch(`https://${url}/.well-known/fursona.json`);
+		if (res.status === 404) {
+			return null
+		}
 	}
 	// Try to parse json, if not return null
 	try {

--- a/src/routes/[domain]/+page.svelte
+++ b/src/routes/[domain]/+page.svelte
@@ -31,7 +31,7 @@
 			.catch((err) => {
 				// Set p content to error
 				const p = document.querySelector('p');
-				p.innerHTML = `Error: Fursona resource (<code>https://${$page.params.domain}/.well-known/fursona</code>) not found <br /><code>${err}</code>`;
+				p.innerHTML = `Error: Fursona resource (<code>https://${$page.params.domain}/.well-known/fursona</code> or <code>https://${$page.params.domain}/.well-known/fursona.json</code>) not found <br /><code>${err}</code>`;
 			});
 	}
 </script>


### PR DESCRIPTION
This is needed for hosts such as Neocities, which have a [file extension whitelist](https://github.com/neocities/neocities/blob/master/views/site_files/allowed_types.erb#L12-L22), and because the default path does not have a file extension, than users of Neocities are unable to upload their fursona file to their website.